### PR TITLE
Remove 'disable-gpu' flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,6 @@ func main() {
 		agouti.ChromeOptions(
 			"args", []string{
 				"headless",
-				"disable-gpu",
 				"no-default-browser-check",
 				"verbose",
 				"no-sandbox",


### PR DESCRIPTION
'disable-gpu' flag prevents from testing WebGL applications.

If there is no strong reason to have 'disable-gpu', I'd want to remove this.
