### PR TITLE
Pass Go test flags and environment variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -250,9 +250,7 @@ func (r *runnerData) testPkg(pkg string) (bool, error) {
 	status := "ok  "
 	start := time.Now()
 
-	var argsValue []string
-	argsValue = append(argsValue, "/fake/program", "/fake/script.js")
-	argsValue = append(argsValue, r.testflags...)
+	argsValue := append([]string{"/fake/program", "/fake/script.js"}, r.testflags...)
 
 	var envValue = make(map[string]string)
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,16 @@ const (
 var (
 	fTags   = flag.String("tags", "", "tags to pass to the GopherJS compiler")
 	fBinary = flag.String("binary", "", "path to Chrome binary")
+	fEnv    = flag.Bool("env", true, "Pass environment variables to runtime.")
+
+	// Six flags copied almost verbatim from gopherjs.  (They start with a
+	// single '-', like the go test flags.)
+	fBench     = flag.String("bench", "", "Run benchmarks matching the regular expression. By default, no benchmarks run. To run all benchmarks, use '-bench=.'.")
+	fBenchtime = flag.String("benchtime", "", "Run enough iterations of each benchmark to take t, specified as a time.Duration (for example, -benchtime 1h30s). The default is 1 second (1s).")
+	fCount     = flag.String("count", "", "Run each test and benchmark n times (default 1). Examples are always run once.")
+	fRun       = flag.String("run", "", "Run only those tests and examples matching the regular expression.")
+	fShort     = flag.Bool("short", false, "Tell long-running tests to shorten their run time.")
+	fVerbose   = flag.Bool("v", false, "Log all tests as they are run. Also print all text from Log and Logf calls even if the test succeeds.")
 
 	testFailure = errors.New("test failure")
 )
@@ -57,9 +67,10 @@ func handleError(err error) {
 }
 
 type runnerData struct {
-	driver *agouti.WebDriver
-	wd     string
-	tags   string
+	driver    *agouti.WebDriver
+	wd        string
+	tags      string
+	testflags []string
 }
 
 func runChrome() error {
@@ -136,6 +147,24 @@ func runChrome() error {
 		driver: driver,
 		wd:     wd,
 		tags:   *fTags,
+	}
+	if *fBench != "" {
+		runner.testflags = append(runner.testflags, "-test.bench", *fBench)
+	}
+	if *fBenchtime != "" {
+		runner.testflags = append(runner.testflags, "-test.benchtime", *fBenchtime)
+	}
+	if *fCount != "" {
+		runner.testflags = append(runner.testflags, "-test.count", *fCount)
+	}
+	if *fRun != "" {
+		runner.testflags = append(runner.testflags, "-test.run", *fRun)
+	}
+	if *fShort {
+		runner.testflags = append(runner.testflags, "-test.short")
+	}
+	if *fVerbose {
+		runner.testflags = append(runner.testflags, "-test.v")
 	}
 
 	failed := false
@@ -221,7 +250,34 @@ func (r *runnerData) testPkg(pkg string) (bool, error) {
 	status := "ok  "
 	start := time.Now()
 
-	err = p.RunScript(`try {
+	var argsValue []string
+	argsValue = append(argsValue, "/fake/program", "/fake/script.js")
+	argsValue = append(argsValue, r.testflags...)
+
+	var envValue = make(map[string]string)
+
+	arguments := make(map[string]interface{})
+	arguments["argv"] = argsValue
+	arguments["env"] = envValue
+
+	if *fEnv {
+		for _, env := range os.Environ() {
+			if index := strings.Index(env, "="); index != -1 {
+				envValue[env[:index]] = env[index+1:]
+			}
+		}
+	}
+
+	// process.exit has to be provided, even if just a no-op, since the
+	// generated gopherjs code checks for the existence of the global process
+	// variable but then assumes the existence of process.exit (same for
+	// process.env).
+	err = p.RunScript(`
+		try {
+			window.process = { };
+			window.process.argv = argv;
+			window.process.env = env;
+			window.process.exit = function(exitcode) {};
 			`+string(test)+`
 		}
 		catch (e) {
@@ -235,7 +291,7 @@ func (r *runnerData) testPkg(pkg string) (bool, error) {
 				ExitCode: window.$GopherJSTestResult
 			}
 		};
-		return window.$GopherJSTestResult`, nil, &ec)
+		return window.$GopherJSTestResult`, arguments, &ec)
 
 	if err != nil {
 		return false, fmtErr("failed to run script: %v")

--- a/main_test.go
+++ b/main_test.go
@@ -26,3 +26,17 @@ func TestFail(t *testing.T) {
 	r.exitCode(1)
 	r.grepBoth("failed for no reason", "failed to find fail output")
 }
+
+func TestEnv(t *testing.T) {
+	r := testRunner(t, "test.004")
+	r.setEnv("BANANA", "banana")
+	r.run()
+	r.exitCode(0)
+}
+
+func TestFlags(t *testing.T) {
+	r := testRunner(t, "test.005")
+	r.run("-v", ".")
+	r.exitCode(0)
+	r.grepBoth("PASS: Test005", "failed to test pass")
+}

--- a/testdata/test.004/init_test.go
+++ b/testdata/test.004/init_test.go
@@ -1,0 +1,16 @@
+// +build js
+
+package main_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+func TestMain(m *testing.M) {
+	i := m.Run()
+
+	js.Global.Call("eval", fmt.Sprintf("window.$GopherJSTestResult = %v", i))
+}

--- a/testdata/test.004/js_test.go
+++ b/testdata/test.004/js_test.go
@@ -1,0 +1,19 @@
+// +build js
+
+package main_test
+
+import (
+	"os"
+	"testing"
+)
+
+const (
+	envVar = "BANANA"
+)
+
+func Test(t *testing.T) {
+	want := "banana"
+	if got := os.Getenv(envVar); got != want {
+		t.Fatalf("expected env %v to be %v; got %v", envVar, want, got)
+	}
+}

--- a/testdata/test.005/init_test.go
+++ b/testdata/test.005/init_test.go
@@ -1,0 +1,16 @@
+// +build js
+
+package main_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+func TestMain(m *testing.M) {
+	i := m.Run()
+
+	js.Global.Call("eval", fmt.Sprintf("window.$GopherJSTestResult = %v", i))
+}

--- a/testdata/test.005/js_test.go
+++ b/testdata/test.005/js_test.go
@@ -1,0 +1,10 @@
+// +build js
+
+package main_test
+
+import (
+	"testing"
+)
+
+func Test005(t *testing.T) {
+}

--- a/util_test.go
+++ b/util_test.go
@@ -47,6 +47,8 @@ type testRunnerData struct {
 
 	ran bool
 
+	env []string
+
 	actExitCode int
 	stdout      bytes.Buffer
 	stderr      bytes.Buffer
@@ -56,7 +58,12 @@ func testRunner(t *testing.T, dir string) *testRunnerData {
 	return &testRunnerData{
 		dir: dir,
 		t:   t,
+		env: os.Environ(),
 	}
+}
+
+func (tr *testRunnerData) setEnv(key, value string) {
+	tr.env = append(tr.env, key+"="+value)
 }
 
 func (tr *testRunnerData) run(flagAndArgs ...string) {
@@ -80,6 +87,7 @@ func (tr *testRunnerData) run(flagAndArgs ...string) {
 	cmd.Dir = filepath.Join(dir)
 	cmd.Stdout = &tr.stdout
 	cmd.Stderr = &tr.stderr
+	cmd.Env = tr.env
 
 	var exitCode int
 


### PR DESCRIPTION
To more closely duplicate the test environment that GopherJS has
created for use with NodeJS, accept Go test flags on the command line
and pass them, as well as the environment variables, as part of the
javascript that is sent to the browser.

Among other things, this enables the use of the -v, -run and -bench
flags. And it provides the code being tested access to the environment
variables through the normal os package mechanism.

If having the environment variables copied into the javascript that gets
loaded into the browser is not desirable, this can be disabled with the
new -env boolean flag. (-env=0 disables environment variables being
copied.)