### PR TITLE
Use Error.prototype.stack for detailed error information

### DIFF
--- a/main.go
+++ b/main.go
@@ -259,7 +259,7 @@ func (r *runnerData) testPkg(pkg string) (bool, error) {
 		}
 		catch (e) {
 			window.$GopherJSTestResult = {
-				Error: e.toString(),
+				Error: e.stack,
 				ExitCode: 1,
 			};
 		};

--- a/main_test.go
+++ b/main_test.go
@@ -40,3 +40,11 @@ func TestFlags(t *testing.T) {
 	r.exitCode(0)
 	r.grepBoth("PASS: Test005", "failed to test pass")
 }
+
+func TestError(t *testing.T) {
+	r := testRunner(t, "test.006")
+	r.run()
+	r.exitCode(1)
+	r.grepBoth("TypeError", "failed to show error class")
+	r.grepBoth("at Test006", "failed to show stack")
+}

--- a/testdata/test.006/init_test.go
+++ b/testdata/test.006/init_test.go
@@ -1,0 +1,16 @@
+// +build js
+
+package main_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+func TestMain(m *testing.M) {
+	i := m.Run()
+
+	js.Global.Call("eval", fmt.Sprintf("window.$GopherJSTestResult = %v", i))
+}

--- a/testdata/test.006/js_test.go
+++ b/testdata/test.006/js_test.go
@@ -1,0 +1,14 @@
+// +build js
+
+package main_test
+
+import (
+	"testing"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+func Test006(t *testing.T) {
+	var x *js.Object
+	x.Call("hello")
+}


### PR DESCRIPTION
This PR replaces `toString` with `stack` so that gjdb users can get detailed error information. `Error.prototype.stack` shows a stack trace like this

```
$ go run ~/go/src/myitcv.io/gjbt/main.go -binary=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome github.com/hajimehoshi/ebiten 
TypeError: Cannot set property 'width' of null
    at Object.$packages.github.com/gopherjs/gopherwasm/js.Value.ptr.Set (<anonymous>:26167:33)
    at Object.$packages.github.com/hajimehoshi/ebiten/internal/ui.userInterface.ptr.updateScreenSize (<anonymous>:43329:33)
    at Object.$packages.github.com/hajimehoshi/ebiten/internal/ui.userInterface.ptr.setScreenSize (<anonymous>:43318:10)
    at Object.Run (<anonymous>:43293:10)
    at run (<anonymous>:45279:11)
    at $b (<anonymous>:45495:9)
    at $goroutine (<anonymous>:1848:19)
    at $runScheduled (<anonymous>:1888:7)
    at $schedule (<anonymous>:1904:5)
    at $go (<anonymous>:1880:3)
    at <anonymous>:125739:1
    at <anonymous>:125742:4
    at apply.ANDROID_HOME (<anonymous>:125757:41)
    at callFunction (<anonymous>:361:33)
    at apply.ANDROID_HOME (<anonymous>:371:23)
    at <anonymous>:372:3
FAIL    github.com/hajimehoshi/ebiten   1.341s
exit status 1
```

Issue: #15 