### PR TITLE
ci: fix running tests on Mac OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,18 @@ matrix:
     - env: CHROMEDRIVER_VERSION=2.38 CHROME_CHANNEL=stable
       addons:
         chrome: stable
+    - env: CHROMEDRIVER_VERSION=2.39 CHROME_CHANNEL=beta
+      addons:
+        chrome: beta
+    - env: CHROMEDRIVER_VERSION=2.39 CHROME_CHANNEL=stable
+      addons:
+        chrome: stable
+    - env: CHROMEDRIVER_VERSION=2.40 CHROME_CHANNEL=beta
+      addons:
+        chrome: beta
+    - env: CHROMEDRIVER_VERSION=2.40 CHROME_CHANNEL=stable
+      addons:
+        chrome: stable
 
 go:
   - 1.10.x

--- a/_scripts/common.bash
+++ b/_scripts/common.bash
@@ -10,7 +10,6 @@ set -o pipefail
 # See https://www.gnu.org/software/bash/manual/html_node/Shell-Functions.html#Shell-Functions
 set -o errtrace
 
-shopt -s globstar
 shopt -s extglob
 
 error() {

--- a/util_test.go
+++ b/util_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -17,6 +18,7 @@ import (
 var gjbt string
 
 func TestMain(m *testing.M) {
+	flag.Parse()
 	td, err := ioutil.TempDir("", "gjbtbin")
 	if err != nil {
 		failf("failed to create gjbt build dir: %v", err)
@@ -77,6 +79,9 @@ func (tr *testRunnerData) run(flagAndArgs ...string) {
 
 	args := []string{"-tags", "js"}
 
+	args = append(args, "-binary", *fBinary)
+	args = append(args, "-driver", *fDriver)
+
 	if len(flagAndArgs) == 0 {
 		args = append(args, ".")
 	} else {
@@ -109,7 +114,7 @@ func (tr *testRunnerData) exitCode(i int) {
 	tr.t.Helper()
 
 	if tr.actExitCode != i {
-		tr.t.Fatalf("exit code; want %v; got %v", i, tr.actExitCode)
+		tr.t.Fatalf("exit code; want %v; got %v\n%s\n%s", i, tr.actExitCode, tr.stdout.String(), tr.stderr.String())
 	}
 }
 


### PR DESCRIPTION
This is just a temporary fix; a longer-term non-shell script fix will land later.

This allows `-binary` and `-driver` to be used to specify the path to Chrome and `chromedriver` respectively during tests. `gopherjs` is still expected to be on your `PATH`:

```
$ go test -driver "/Users/pauljolly/Downloads/chromedriver" -binary "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome"
PASS
ok  	myitcv.io/gjbt	8.719s
```