### PR TITLE
feature: Update fBinary to look for "chrome" on Windows and "google-chrome" on everything else

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ type res struct {
 
 var (
 	fTags   = flag.String("tags", "", "tags to pass to the GopherJS compiler")
-	fBinary = flag.String("binary", "google-chrome", "path to Chrome binary")
+	fBinary = flag.String("binary", chromeBinaryName, "path to Chrome binary")
 	fDriver = flag.String("driver", "chromedriver", "path to chromedriver binary")
 	fEnv    = flag.Bool("env", true, "Pass environment variables to runtime.")
 
@@ -325,7 +325,7 @@ func absPath(s string) string {
 
 	b, err := exec.LookPath(s)
 	if err != nil {
-		handleError(fmt.Errorf("failed to LookPath for %v", s))
+		handleError(fmt.Errorf("Failed to find \"%v\" in your PATH environment variable.", s))
 	}
 	return b
 }

--- a/main_nonwindows.go
+++ b/main_nonwindows.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package main
+
+const (
+	chromeBinaryName = "google-chrome"
+)

--- a/main_windows.go
+++ b/main_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package main
+
+const (
+	chromeBinaryName = "chrome"
+)


### PR DESCRIPTION
- Update fBinary to look for "chrome" on Windows and "google-chrome" on everything else
- Error message was updated to be clearer as I didn't know exec.LookPath did until I looked into it.

I also wanted to say thanks for creating this! It's been really useful for benchmarking the performance of things in my game!